### PR TITLE
What do we want? Mountpoints to not be writable on their own. When do we get it? Not yet.

### DIFF
--- a/ansible/roles/blaze/tasks/localfs.yml
+++ b/ansible/roles/blaze/tasks/localfs.yml
@@ -12,4 +12,4 @@
   file:
     path: "/data"
     state: directory
-    mode: 0700
+    mode: 1777

--- a/ansible/roles/common/tasks/fstab-mill.yml
+++ b/ansible/roles/common/tasks/fstab-mill.yml
@@ -10,4 +10,4 @@
   file:
     path: "/work"
     state: directory
-    mode: 0700
+    mode: 1777

--- a/ansible/roles/havoc/tasks/localfs.yml
+++ b/ansible/roles/havoc/tasks/localfs.yml
@@ -12,4 +12,4 @@
   file:
     path: "/data"
     state: directory
-    mode: 0700
+    mode: 1777

--- a/ansible/roles/s2600wt/tasks/localfs.yml
+++ b/ansible/roles/s2600wt/tasks/localfs.yml
@@ -12,4 +12,4 @@
   file:
     path: "/data"
     state: directory
-    mode: 0700
+    mode: 1777

--- a/ansible/roles/watson/tasks/localfs.yml
+++ b/ansible/roles/watson/tasks/localfs.yml
@@ -12,4 +12,4 @@
   file:
     path: "/data"
     state: directory
-    mode: 0700
+    mode: 1777


### PR DESCRIPTION
Bare/empty mountpoints should not be writable in case the resource to be
mounted does not mount for some reason, else processes will write to the
underlying filesystem, possibly filling it up.

However, this is not yet easily expressed in elegant ansible:

https://stackoverflow.com/questions/34721001/check-if-directory-is-a-mount-point

Come back to this after some table tossing.