### PR TITLE
RISE #1340

### DIFF
--- a/ansible/roles/common/tasks/pkgs.yml
+++ b/ansible/roles/common/tasks/pkgs.yml
@@ -51,3 +51,4 @@
     - pkg-config
     - flex
     - bison
+    - clang-format-3.8 # Alexey really likes this version 


### PR DESCRIPTION
  * clang-format-3.8, independently of the rest of the llvm stack
  - Alexey likes how this particular version formats code