### PR TITLE
Give Eyal <ges> access to docker (RISE #2356)

### DIFF
--- a/ansible/roles/common/tasks/docker.yml
+++ b/ansible/roles/common/tasks/docker.yml
@@ -14,3 +14,20 @@
     name: docker-ce
     state: present
     update_cache: yes
+
+- name: add a "docker" group
+  group:
+    name: docker
+    state: present
+    gid: 998
+    system: yes
+
+- name: add people to docker group
+  user:
+    name: '{{ item }}'
+    groups: docker
+    append: yes
+  with_items:
+    - crankshaw
+    - czumar
+    - ges


### PR DESCRIPTION
  * Add <ges> to "docker" group
  * Also make sure "docker" group is defined locally, not in NIS
  * Also suppress inheritance of that group from EECS NIS (done elsewhere)